### PR TITLE
Fix/title and description analyzers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed image variation generation in `SitemapContentService`
 * Fixed return value of `SitemapContentService::generate()` and `SitemapContentService::generateResults()`
 * Move Doctrine migrations from `bundle/DoctrineMigrations/` to `bundle/migrations/`
+* Fixed title and description analysis in lowercase without accents
 
 ## [1.0.0] - 2021-07-09
 ### Added

--- a/bundle/Analysis/Analyzers/MetaDescriptionContainsKeywordAnalyzer.php
+++ b/bundle/Analysis/Analyzers/MetaDescriptionContainsKeywordAnalyzer.php
@@ -51,7 +51,7 @@ final class MetaDescriptionContainsKeywordAnalyzer extends AbstractAnalyzer
                 /** @var \DOMElement $metaDescriptionTag */
                 foreach ($metaDescriptionTags as $metaDescriptionTag) {
                     foreach ($keywordSynonyms as $keyword) {
-                        $contentMetaDescriptionTagAttribute = $metaDescriptionTag->getAttribute('content');
+                        $contentMetaDescriptionTagAttribute = \strtr(\mb_strtolower($metaDescriptionTag->getAttribute('content')), AnalyzerService::ACCENT_VALUES);
                         if (false !== \mb_strpos($contentMetaDescriptionTagAttribute, $keyword)) {
                             $status = RatioLevels::HIGH;
                             break;

--- a/bundle/Analysis/Analyzers/TitleTagContainsKeywordAnalyzer.php
+++ b/bundle/Analysis/Analyzers/TitleTagContainsKeywordAnalyzer.php
@@ -51,7 +51,7 @@ final class TitleTagContainsKeywordAnalyzer extends AbstractAnalyzer
                 /** @var \DOMElement $titleTag */
                 foreach ($titleTags as $titleTag) {
                     foreach ($keywordSynonyms as $keyword) {
-                        $contentTitleTagAttribute = $titleTag->getAttribute('content');
+                        $contentTitleTagAttribute = \strtr(\mb_strtolower($titleTag->textContent), AnalyzerService::ACCENT_VALUES);
                         if (false !== \mb_strpos($contentTitleTagAttribute, $keyword)) {
                             $status = RatioLevels::HIGH;
                             break;


### PR DESCRIPTION
Fixes access to the `title` tag text content
Fixes comparison of `title` and `description` to the configured keywords in lower with accent replacement