### PR TITLE
Append SEO toolkit button in the same way on page builder contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed return value of `SitemapContentService::generate()` and `SitemapContentService::generateResults()`
 * Move Doctrine migrations from `bundle/DoctrineMigrations/` to `bundle/migrations/`
 * Fixed title and description analysis in lowercase without accents
+* [Admin UI] Fixed edition right toolbar button handling between contents with or without page builder
 
 ## [1.0.0] - 2021-07-09
 ### Added

--- a/bundle/EventListener/AbstractToolbarMenuListener.php
+++ b/bundle/EventListener/AbstractToolbarMenuListener.php
@@ -15,18 +15,10 @@ abstract class AbstractToolbarMenuListener
         $this->siteAccessConfigResolver = $siteAccessConfigResolver;
     }
 
-    protected function getCurrentContentTypeIdentifier(array $options): ?string
-    {
-        if(isset($options['content']) && $options['content'] instanceof Content) {
-            return $options['content']->getContentType()->identifier;
-        }
-        return null;
-    }
-
     public function onMenuConfigure(ConfigureMenuEvent $configureMenuEvent): void
     {
         $currentContentTypeIdentifier = $this->getCurrentContentTypeIdentifier($configureMenuEvent->getOptions());
-        if(null === $currentContentTypeIdentifier) {
+        if (null === $currentContentTypeIdentifier) {
             return;
         }
 
@@ -34,7 +26,7 @@ abstract class AbstractToolbarMenuListener
 
         $menuItem = $configureMenuEvent->getMenu();
 
-        if (!array_key_exists('content_types', $analysisConfiguration) or !in_array($currentContentTypeIdentifier, array_keys($analysisConfiguration['content_types']))) {
+        if (!\array_key_exists('content_types', $analysisConfiguration) || !\in_array($currentContentTypeIdentifier, array_keys($analysisConfiguration['content_types']), true)) {
             $menuItem->addChild(
                 'menu_item_seo_analyzer_not_configured',
                 [
@@ -46,9 +38,9 @@ abstract class AbstractToolbarMenuListener
                     ],
                 ]
             );
+
             return;
         }
-
 
         $menuItem->addChild(
             'menu_item_seo_analyzer',
@@ -61,5 +53,14 @@ abstract class AbstractToolbarMenuListener
                 ],
             ]
         );
+    }
+
+    protected function getCurrentContentTypeIdentifier(array $options): ?string
+    {
+        if (isset($options['content']) && $options['content'] instanceof Content) {
+            return $options['content']->getContentType()->identifier;
+        }
+
+        return null;
     }
 }

--- a/bundle/EventListener/AbstractToolbarMenuListener.php
+++ b/bundle/EventListener/AbstractToolbarMenuListener.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Codein\IbexaSeoToolkit\EventListener;
+
+use Codein\IbexaSeoToolkit\Helper\SiteAccessConfigResolver;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
+
+abstract class AbstractToolbarMenuListener
+{
+    protected $siteAccessConfigResolver;
+
+    public function __construct(SiteAccessConfigResolver $siteAccessConfigResolver)
+    {
+        $this->siteAccessConfigResolver = $siteAccessConfigResolver;
+    }
+
+    protected function getCurrentContentTypeIdentifier(array $options): ?string
+    {
+        if(isset($options['content']) && $options['content'] instanceof Content) {
+            return $options['content']->getContentType()->identifier;
+        }
+        return null;
+    }
+
+    public function onMenuConfigure(ConfigureMenuEvent $configureMenuEvent): void
+    {
+        $currentContentTypeIdentifier = $this->getCurrentContentTypeIdentifier($configureMenuEvent->getOptions());
+        if(null === $currentContentTypeIdentifier) {
+            return;
+        }
+
+        $analysisConfiguration = $this->siteAccessConfigResolver->getParameterConfig('analysis');
+
+        $menuItem = $configureMenuEvent->getMenu();
+
+        if (!array_key_exists('content_types', $analysisConfiguration) or !in_array($currentContentTypeIdentifier, array_keys($analysisConfiguration['content_types']))) {
+            $menuItem->addChild(
+                'menu_item_seo_analyzer_not_configured',
+                [
+                    'label' => 'codein_seo_toolkit.content_create_edit.menu_label',
+                    'uri' => '#codein-seo-not-configured',
+                    'extras' => [
+                        'icon_path' => '/bundles/codein-ibexaseotoolkit/images/SEO-Toolkit_logo.svg#codein-seo-toolkit-logo',
+                        'translation_domain' => 'codein_seo_toolkit',
+                    ],
+                ]
+            );
+            return;
+        }
+
+
+        $menuItem->addChild(
+            'menu_item_seo_analyzer',
+            [
+                'label' => 'codein_seo_toolkit.content_create_edit.menu_label',
+                'uri' => '#codein-seo-move-in',
+                'extras' => [
+                    'icon_path' => '/bundles/codein-ibexaseotoolkit/images/SEO-Toolkit_logo.svg#codein-seo-toolkit-logo',
+                    'translation_domain' => 'codein_seo_toolkit',
+                ],
+            ]
+        );
+    }
+}

--- a/bundle/EventListener/ContentCreateEditRightMenuListener.php
+++ b/bundle/EventListener/ContentCreateEditRightMenuListener.php
@@ -2,55 +2,11 @@
 
 namespace Codein\IbexaSeoToolkit\EventListener;
 
-use Codein\IbexaSeoToolkit\Helper\SiteAccessConfigResolver;
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-final class ContentCreateEditRightMenuListener implements EventSubscriberInterface
+final class ContentCreateEditRightMenuListener extends AbstractToolbarMenuListener implements EventSubscriberInterface
 {
-    private $siteAccessConfigResolver;
-
-    public function __construct(SiteAccessConfigResolver $siteAccessConfigResolver)
-    {
-        $this->siteAccessConfigResolver = $siteAccessConfigResolver;
-    }
-
-    public function onMenuConfigure(ConfigureMenuEvent $configureMenuEvent): void
-    {
-        $currentContentTypeIdentifier = $configureMenuEvent->getOptions()['content_type']->identifier;
-        $analysisConfiguration = $this->siteAccessConfigResolver->getParameterConfig('analysis');
-
-        $menuItem = $configureMenuEvent->getMenu();
-
-        if (!\array_key_exists('content_types', $analysisConfiguration) || !\in_array($currentContentTypeIdentifier, array_keys($analysisConfiguration['content_types']), true)) {
-            $menuItem->addChild(
-                'menu_item_seo_analyzer_not_configured',
-                [
-                    'label' => 'codein_seo_toolkit.content_create_edit.menu_label',
-                    'uri' => '#codein-seo-not-configured',
-                    'extras' => [
-                        'icon_path' => '/bundles/codein-ibexaseotoolkit/images/SEO-Toolkit_logo.svg#codein-seo-toolkit-logo',
-                        'translation_domain' => 'codein_seo_toolkit',
-                    ],
-                ]
-            );
-
-            return;
-        }
-
-        $menuItem->addChild(
-            'menu_item_seo_analyzer',
-            [
-                'label' => 'codein_seo_toolkit.content_create_edit.menu_label',
-                'uri' => '#codein-seo-move-in',
-                'extras' => [
-                    'icon_path' => '/bundles/codein-ibexaseotoolkit/images/SEO-Toolkit_logo.svg#codein-seo-toolkit-logo',
-                    'translation_domain' => 'codein_seo_toolkit',
-                ],
-            ]
-        );
-    }
-
     public static function getSubscribedEvents()
     {
         return [

--- a/bundle/EventListener/PageBuilderMenuListener.php
+++ b/bundle/EventListener/PageBuilderMenuListener.php
@@ -2,48 +2,12 @@
 
 namespace Codein\IbexaSeoToolkit\EventListener;
 
-use Codein\IbexaSeoToolkit\Helper\SiteAccessConfigResolver;
 use EzSystems\EzPlatformAdminUi\Menu\Event\ConfigureMenuEvent;
 
-class PageBuilderMenuListener
+class PageBuilderMenuListener extends AbstractToolbarMenuListener
 {
-    private $siteAccessConfigResolver;
-
-    public function __construct(SiteAccessConfigResolver $siteAccessConfigResolver)
-    {
-        $this->siteAccessConfigResolver = $siteAccessConfigResolver;
-    }
-
     public function onPageBuilderMenuConfigure(ConfigureMenuEvent $configureMenuEvent): void
     {
-        $currentContentTypeIdentifier = $configureMenuEvent->getOptions()['content']->getContentType()->identifier;
-        $analysisConfiguration = $this->siteAccessConfigResolver->getParameterConfig('analysis');
-        if (!\array_key_exists('content_types', $analysisConfiguration)) {
-            return;
-        }
-
-        if (!\in_array($currentContentTypeIdentifier, array_keys($analysisConfiguration['content_types']), true)) {
-            return;
-        }
-
-        $root = $configureMenuEvent->getMenu();
-        $root->addChild(
-            'menu_item_seo_analyzer',
-            [
-                'attributes' => [
-                    // 'class' => 'ez-btn--extra-actions',
-                    'id' => 'menu_item_seo_analyzer-tab',
-                    'data-actions' => 'seo-analyzer',
-                    'title' => 'test',
-                ],
-                'uri' => '#codein-seo-move-in',
-                'extras' => [
-                    'translation_domain' => 'codein_seo_toolkit',
-                    'icon_path' => '/bundles/codein-ibexaseotoolkit/images/SEO-Toolkit_logo.svg#codein-seo-toolkit-logo',
-                    // 'template' => 'EzSystemsDateBasedPublisherBundle::publish_later_widget.html.twig',
-                    'orderNumber' => 20,
-                ],
-            ]
-        );
+        $this->onMenuConfigure($configureMenuEvent);
     }
 }


### PR DESCRIPTION
On a content / edit view, the SEO toolkit right toolbar button differs between contents using page builder or not.

Using an abstract class appends the button to the toolbar with the same logic.