### PR TITLE
Fix/url slug analyser without richtext and sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.1
+## [Unreleased]
 ### Changed
 
 * Fixed versions requirements in the docs to be consistent.
 * Use `ezpublish.api.service.inner_schema_namer` factory instead of the internal schema_namer service (#8)
 * Removal of `codein_ibexa_seo_toolkit.seo_analyzer` yaml service tag declaration. Replaced by DI `registerForAutoconfiguration`
 * Adding SitemapQuery Extensibility point through `Codein\IbexaSeoToolkit\Event\SitemapQueryEvent`
+* Allow `KeywordInUrlSlugAnalyzer` to run event if no richtext is configured
+* Fixed content type filtering with multiple content types in `SitemapQueryHelper`
+* Fixed image variation generation in `SitemapContentService`
+* Fixed return value of `SitemapContentService::generate()` and `SitemapContentService::generateResults()`
 
 ## [1.0.0] - 2021-07-09
 ### Added

--- a/bundle/Analysis/Analyzers/KeywordInUrlSlugAnalyzer.php
+++ b/bundle/Analysis/Analyzers/KeywordInUrlSlugAnalyzer.php
@@ -13,8 +13,6 @@ use eZ\Publish\API\Repository\URLAliasService;
  * Class KeywordInUrlSlugAnalyzer.
  *
  * Look for keyword in URL Slug
- *
- * This could be implemented as a richtext analyzer as well as it doesn't need access to content specifically
  */
 final class KeywordInUrlSlugAnalyzer extends AbstractAnalyzer
 {
@@ -84,11 +82,6 @@ final class KeywordInUrlSlugAnalyzer extends AbstractAnalyzer
         // Difficult to get non latin alphabet languages
         // to work well with this analyzer.
         // Moreover, we don't know how Search Engines treats them
-
-        if (0 === \count($analysisDTO->getFields())) {
-            return false;
-        }
-
         return !\in_array($analysisDTO->getLanguageCode(), [
             'ara-SA',
             'chi-CN',

--- a/bundle/Event/SitemapQueryEvent.php
+++ b/bundle/Event/SitemapQueryEvent.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Codein\IbexaSeoToolkit\Event;
 
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use Symfony\Contracts\EventDispatcher\Event;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class SitemapQueryEvent extends Event
 {
@@ -14,13 +14,13 @@ class SitemapQueryEvent extends Event
     /** @var string */
     private $specificContentType;
 
-    /** @var Criterion[]  */
+    /** @var Criterion[] */
     private $baseCriteria;
 
-    /** @var Criterion[]  */
+    /** @var Criterion[] */
     private $blocklistCriteria;
 
-    /** @var Criterion[]  */
+    /** @var Criterion[] */
     private $passlistCriteria;
 
     public function __construct(LocationQuery $locationQuery, array $baseCriteria, array $blocklistCriteria, array $passlistCriteria, string $specificContentType)
@@ -32,33 +32,21 @@ class SitemapQueryEvent extends Event
         $this->passlistCriteria = $passlistCriteria;
     }
 
-    /**
-     * @return LocationQuery
-     */
     public function getLocationQuery(): LocationQuery
     {
         return $this->locationQuery;
     }
 
-    /**
-     * @param LocationQuery $locationQuery
-     */
     public function setLocationQuery(LocationQuery $locationQuery): void
     {
         $this->locationQuery = $locationQuery;
     }
 
-    /**
-     * @return string
-     */
     public function getSpecificContentType(): string
     {
         return $this->specificContentType;
     }
 
-    /**
-     * @param string $specificContentType
-     */
     public function setSpecificContentType(string $specificContentType): void
     {
         $this->specificContentType = $specificContentType;

--- a/bundle/EventSubscriber/SitemapQueryEventSubscriber.php
+++ b/bundle/EventSubscriber/SitemapQueryEventSubscriber.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Codein\IbexaSeoToolkit\EventSubscriber;
 
 use Codein\IbexaSeoToolkit\Event\SitemapQueryEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class SitemapQueryEventSubscriber implements EventSubscriberInterface
 {

--- a/bundle/Helper/SitemapQueryHelper.php
+++ b/bundle/Helper/SitemapQueryHelper.php
@@ -146,13 +146,18 @@ final class SitemapQueryHelper
             $criteria[] = new Criterion\Subtree($subtree->pathString);
         }
 
+        $contentTypeIdentifiersList = [];
         foreach ($contentTypeIdentifiers as $contentTypeIdentifier) {
             try {
                 $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
             } catch (\eZ\Publish\API\Repository\Exceptions\NotFoundException $e) {
                 continue;
             }
-            $criteria[] = new Criterion\ContentTypeIdentifier($contentTypeIdentifier);
+            $contentTypeIdentifiersList[] = $contentTypeIdentifier;
+        }
+
+        if(!empty($contentTypeIdentifiersList)) {
+            $criteria[] = new Criterion\ContentTypeIdentifier($contentTypeIdentifiersList);
         }
 
         return $criteria;

--- a/bundle/Helper/SitemapQueryHelper.php
+++ b/bundle/Helper/SitemapQueryHelper.php
@@ -3,11 +3,11 @@
 namespace Codein\IbexaSeoToolkit\Helper;
 
 use Codein\IbexaSeoToolkit\Event\SitemapQueryEvent;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\API\Repository\Repository;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -63,6 +63,7 @@ final class SitemapQueryHelper
             $this->getPasslistCriteria(),
             $specificContentType
         ));
+
         return $event->getLocationQuery();
     }
 
@@ -75,7 +76,7 @@ final class SitemapQueryHelper
         return [new Criterion\Subtree($siteaccessRootLocation->pathString)];
     }
 
-    private function getBlocklistCriteria() : array
+    private function getBlocklistCriteria(): array
     {
         $sitemapConfiguration = $this->siteAccessConfigResolver->getParameterConfig('sitemap');
         $blocklistCriteria = [];
@@ -98,7 +99,7 @@ final class SitemapQueryHelper
         return $blocklistCriteria;
     }
 
-    private function getPasslistCriteria() : array
+    private function getPasslistCriteria(): array
     {
         $sitemapConfiguration = $this->siteAccessConfigResolver->getParameterConfig('sitemap');
         $passlistCriteria = [];
@@ -113,6 +114,7 @@ final class SitemapQueryHelper
                 $contentTypeIdentifiers
             );
         }
+
         return $passlistCriteria;
     }
 
@@ -156,7 +158,7 @@ final class SitemapQueryHelper
             $contentTypeIdentifiersList[] = $contentTypeIdentifier;
         }
 
-        if(!empty($contentTypeIdentifiersList)) {
+        if (!empty($contentTypeIdentifiersList)) {
             $criteria[] = new Criterion\ContentTypeIdentifier($contentTypeIdentifiersList);
         }
 

--- a/bundle/Service/SitemapContentService.php
+++ b/bundle/Service/SitemapContentService.php
@@ -6,6 +6,7 @@ use Codein\IbexaSeoToolkit\Helper\SiteAccessConfigResolver;
 use Codein\IbexaSeoToolkit\Helper\SitemapQueryHelper;
 use DOMDocument;
 use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\Core\Helper\FieldHelper;
 use eZ\Publish\SPI\Variation\VariationHandler;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -21,12 +22,14 @@ final class SitemapContentService
     private $variationHandler;
     private $sitemapQueryHelper;
     private $siteAccessConfigResolver;
+    private $fieldHelper;
 
     public function __construct(
         SiteAccessConfigResolver $siteAccessConfigResolver,
         UrlGeneratorInterface $urlGenerator,
         SearchService $searchService,
         SitemapQueryHelper $sitemapQueryHelper,
+        FieldHelper $fieldHelper,
         RequestStack $requestStack
     ) {
         $this->siteAccessConfigResolver = $siteAccessConfigResolver;
@@ -34,9 +37,10 @@ final class SitemapContentService
         $this->searchService = $searchService;
         $this->sitemapQueryHelper = $sitemapQueryHelper;
         $this->requestStack = $requestStack;
+        $this->fieldHelper = $fieldHelper;
     }
 
-    public function generate()
+    public function generate(): DOMDocument
     {
         $sitemapConfiguration = $this->siteAccessConfigResolver->getParameterConfig('sitemap');
         $limit = $sitemapConfiguration['max_items_per_page'];
@@ -162,7 +166,7 @@ final class SitemapContentService
         DOMDocument $sitemap,
         \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $queryResults,
         bool $useImages
-    ): ?DOMDocument {
+    ): DOMDocument {
         $sitemapUrlset = $sitemap->createElement('urlset');
         $sitemapUrlset->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
         $sitemapUrlset->setAttribute('xmlns:image', 'http://www.google.com/schemas/sitemap-image/1.1');
@@ -171,7 +175,7 @@ final class SitemapContentService
         $sitemap->appendChild($sitemapUrlset);
 
         if (0 === $queryResults->totalCount) {
-            return null;
+            return $sitemap;
         }
 
         foreach ($queryResults->searchHits as $queryResult) {
@@ -200,7 +204,11 @@ final class SitemapContentService
                     if ('ezimage' !== $field->fieldTypeIdentifier) {
                         continue;
                     }
-                    $variation = $this->variationHandler->getVariation($field, new \eZ\Publish\Core\Repository\Values\Content\VersionInfo(), 'original');
+                    if($this->fieldHelper->isFieldEmpty($location->getContent(), $field->fieldDefIdentifier)) {
+                        continue;
+                    }
+
+                    $variation = $this->variationHandler->getVariation($field, $location->getContent()->getVersionInfo(), 'original');
 
                     $imageBlock = $sitemap->createElement('image:image');
                     $imageLoc = $sitemap->createElement('image:loc', $variation->uri);

--- a/bundle/Service/SitemapContentService.php
+++ b/bundle/Service/SitemapContentService.php
@@ -204,7 +204,7 @@ final class SitemapContentService
                     if ('ezimage' !== $field->fieldTypeIdentifier) {
                         continue;
                     }
-                    if($this->fieldHelper->isFieldEmpty($location->getContent(), $field->fieldDefIdentifier)) {
+                    if ($this->fieldHelper->isFieldEmpty($location->getContent(), $field->fieldDefIdentifier)) {
                         continue;
                     }
 


### PR DESCRIPTION
Concerning the KeywordInUrlSlugAnalyzer
- KeywordInUrlSlugAnalyzer should run even if content has no richtext fields

Concerning SitemapQueryHelper
- ContentTypeIdentifier criterion must be added once with all wished content types instead of once per content type
  - We need to get a search request like `ContentTypeIdentifier IN (a, b, c)` instead of `ContentTypeIdentifier IN (a) AND ContentTypeIdentifier IN (b) AND ...` which gives not result

Concerning the sitemap generator
- SitemapContentService::generate() and SitemapContentService::generateResults() has always to return a DOMDocument
  - DOMDocument is required by all others method calls and by the controller
- For the image variation generation
  - eZ\Publish\API\Repository\Values\Content\VersionInfo is abstract and cannot be instanciated
  - Generate the image variation only if field is not empty