### PR TITLE
Fix/analyzer tag autoconfiguration and sitemap query event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed versions requirements in the docs to be consistent.
 * Use `ezpublish.api.service.inner_schema_namer` factory instead of the internal schema_namer service (#8)
+* Removal of `codein_ibexa_seo_toolkit.seo_analyzer` yaml service tag declaration. Replaced by DI `registerForAutoconfiguration`
+* Adding SitemapQuery Extensibility point through `Codein\IbexaSeoToolkit\Event\SitemapQueryEvent`
 
 ## [1.0.0] - 2021-07-09
 ### Added

--- a/bundle/Event/SitemapQueryEvent.php
+++ b/bundle/Event/SitemapQueryEvent.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Codein\IbexaSeoToolkit\Event;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use Symfony\Contracts\EventDispatcher\Event;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+class SitemapQueryEvent extends Event
+{
+    /** @var LocationQuery */
+    private $locationQuery;
+
+    /** @var string */
+    private $specificContentType;
+
+    /** @var Criterion[]  */
+    private $baseCriteria;
+
+    /** @var Criterion[]  */
+    private $blocklistCriteria;
+
+    /** @var Criterion[]  */
+    private $passlistCriteria;
+
+    public function __construct(LocationQuery $locationQuery, array $baseCriteria, array $blocklistCriteria, array $passlistCriteria, string $specificContentType)
+    {
+        $this->locationQuery = $locationQuery;
+        $this->specificContentType = $specificContentType;
+        $this->baseCriteria = $baseCriteria;
+        $this->blocklistCriteria = $blocklistCriteria;
+        $this->passlistCriteria = $passlistCriteria;
+    }
+
+    /**
+     * @return LocationQuery
+     */
+    public function getLocationQuery(): LocationQuery
+    {
+        return $this->locationQuery;
+    }
+
+    /**
+     * @param LocationQuery $locationQuery
+     */
+    public function setLocationQuery(LocationQuery $locationQuery): void
+    {
+        $this->locationQuery = $locationQuery;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSpecificContentType(): string
+    {
+        return $this->specificContentType;
+    }
+
+    /**
+     * @param string $specificContentType
+     */
+    public function setSpecificContentType(string $specificContentType): void
+    {
+        $this->specificContentType = $specificContentType;
+    }
+
+    public function hasSpecificContentType(): bool
+    {
+        return !empty($this->specificContentType);
+    }
+
+    /**
+     * @return Criterion[]
+     */
+    public function getBaseCriteria(): array
+    {
+        return $this->baseCriteria;
+    }
+
+    /**
+     * @param Criterion[] $baseCriteria
+     */
+    public function setBaseCriteria(array $baseCriteria): void
+    {
+        $this->baseCriteria = $baseCriteria;
+    }
+
+    /**
+     * @return Criterion[]
+     */
+    public function getBlocklistCriteria(): array
+    {
+        return $this->blocklistCriteria;
+    }
+
+    /**
+     * @param Criterion[] $blocklistCriteria
+     */
+    public function setBlocklistCriteria(array $blocklistCriteria): void
+    {
+        $this->blocklistCriteria = $blocklistCriteria;
+    }
+
+    /**
+     * @return Criterion[]
+     */
+    public function getPasslistCriteria(): array
+    {
+        return $this->passlistCriteria;
+    }
+
+    /**
+     * @param Criterion[] $passlistCriteria
+     */
+    public function setPasslistCriteria(array $passlistCriteria): void
+    {
+        $this->passlistCriteria = $passlistCriteria;
+    }
+}

--- a/bundle/EventSubscriber/SitemapQueryEventSubscriber.php
+++ b/bundle/EventSubscriber/SitemapQueryEventSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Codein\IbexaSeoToolkit\EventSubscriber;
+
+use Codein\IbexaSeoToolkit\Event\SitemapQueryEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+class SitemapQueryEventSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        // return the subscribed events, their methods and priorities
+        return [
+            SitemapQueryEvent::class => [
+                ['defaultSitemapQueryCriterions', -1000],
+            ],
+        ];
+    }
+
+    public function defaultSitemapQueryCriterions(SitemapQueryEvent $event)
+    {
+        $event->getLocationQuery()->query = new Criterion\LogicalAnd(
+            \array_merge(
+                $event->getBaseCriteria(),
+                $event->getBlocklistCriteria(),
+                $event->getPasslistCriteria(),
+            )
+        );
+    }
+}

--- a/bundle/Helper/SitemapQueryHelper.php
+++ b/bundle/Helper/SitemapQueryHelper.php
@@ -2,11 +2,13 @@
 
 namespace Codein\IbexaSeoToolkit\Helper;
 
-use eZ\Publish\API\Repository\Repository;
+use Codein\IbexaSeoToolkit\Event\SitemapQueryEvent;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Repository;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Class SitemapQueryHelper
@@ -20,12 +22,17 @@ final class SitemapQueryHelper
     /** @var SiteAccessConfigResolver */
     private $siteAccessConfigResolver;
 
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
     public function __construct(
         Repository $repository,
-        SiteAccessConfigResolver $siteAccessConfigResolver
+        SiteAccessConfigResolver $siteAccessConfigResolver,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->repository = $repository;
         $this->siteAccessConfigResolver = $siteAccessConfigResolver;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -37,28 +44,29 @@ final class SitemapQueryHelper
     {
         $query = new LocationQuery();
 
-        $baseCriteria = [
-            new Criterion\Visibility(Criterion\Visibility::VISIBLE),
-        ];
+        $baseCriteria = $this->generateSiteaccessRootLocationCriterion();
+        $baseCriteria[] = new Criterion\Visibility(Criterion\Visibility::VISIBLE);
 
         if (\mb_strlen($specificContentType)) {
             $baseCriteria[] = new Criterion\ContentTypeIdentifier($specificContentType);
         }
 
-        $query->query = new Criterion\LogicalAnd(
-            \array_merge(
-                $baseCriteria,
-                $this->createGenericFilterCriteria()
-            )
-        );
         $query->sortClauses = [
             new SortClause\DatePublished(LocationQuery::SORT_DESC),
         ];
 
-        return $query;
+        /** @var SitemapQueryEvent $event */
+        $event = $this->eventDispatcher->dispatch(new SitemapQueryEvent(
+            $query,
+            $baseCriteria,
+            $this->getBlocklistCriteria(),
+            $this->getPasslistCriteria(),
+            $specificContentType
+        ));
+        return $event->getLocationQuery();
     }
 
-    public function generateSiteaccessRootLocationCriterion(): array
+    private function generateSiteaccessRootLocationCriterion(): array
     {
         $siteaccessRootLocation = $this->repository->getLocationService()->loadLocation(
             $this->siteAccessConfigResolver->getConfigResolver()->getParameter('content.tree_root.location_id')
@@ -67,13 +75,10 @@ final class SitemapQueryHelper
         return [new Criterion\Subtree($siteaccessRootLocation->pathString)];
     }
 
-    private function createGenericFilterCriteria(): array
+    private function getBlocklistCriteria() : array
     {
         $sitemapConfiguration = $this->siteAccessConfigResolver->getParameterConfig('sitemap');
-
         $blocklistCriteria = [];
-        $passlistCriteria = [];
-
         if (\array_key_exists('blocklist', $sitemapConfiguration)) {
             $locations = $sitemapConfiguration['blocklist']['locations'];
             $subtrees = $sitemapConfiguration['blocklist']['subtrees'];
@@ -89,6 +94,14 @@ final class SitemapQueryHelper
                 return new Criterion\LogicalNot($criterion);
             }, $criteria);
         }
+
+        return $blocklistCriteria;
+    }
+
+    private function getPasslistCriteria() : array
+    {
+        $sitemapConfiguration = $this->siteAccessConfigResolver->getParameterConfig('sitemap');
+        $passlistCriteria = [];
         if (\array_key_exists('passlist', $sitemapConfiguration)) {
             $locations = $sitemapConfiguration['passlist']['locations'];
             $subtrees = $sitemapConfiguration['passlist']['subtrees'];
@@ -100,12 +113,7 @@ final class SitemapQueryHelper
                 $contentTypeIdentifiers
             );
         }
-
-        return \array_merge(
-            $this->generateSiteaccessRootLocationCriterion(),
-            $blocklistCriteria,
-            $passlistCriteria,
-        );
+        return $passlistCriteria;
     }
 
     private function calculateCriteria(

--- a/bundle/IbexaSeoToolkitBundle.php
+++ b/bundle/IbexaSeoToolkitBundle.php
@@ -26,9 +26,9 @@ class IbexaSeoToolkitBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new AnalyzerPass());
+
         $container->registerForAutoconfiguration(AnalyzerInterface::class)
             ->addTag(AnalyzerPass::TAG_NAME);
-
-        $container->addCompilerPass(new AnalyzerPass());
     }
 }

--- a/bundle/IbexaSeoToolkitBundle.php
+++ b/bundle/IbexaSeoToolkitBundle.php
@@ -2,6 +2,7 @@
 
 namespace Codein\IbexaSeoToolkit;
 
+use Codein\IbexaSeoToolkit\Analysis\AnalyzerInterface;
 use Codein\IbexaSeoToolkit\DependencyInjection\Compiler\AnalyzerPass;
 use Codein\IbexaSeoToolkit\DependencyInjection\IbexaSeoToolkitExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -24,6 +25,9 @@ class IbexaSeoToolkitBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);
+
+        $container->registerForAutoconfiguration(AnalyzerInterface::class)
+            ->addTag(AnalyzerPass::TAG_NAME);
 
         $container->addCompilerPass(new AnalyzerPass());
     }

--- a/bundle/Resources/config/services.yaml
+++ b/bundle/Resources/config/services.yaml
@@ -19,8 +19,12 @@ services:
 
     Codein\IbexaSeoToolkit\Service\:
         resource: '../../Service'
+
     Codein\IbexaSeoToolkit\Helper\:
         resource: '../../Helper'
+
+    Codein\IbexaSeoToolkit\EventSubscriber\:
+        resource: '../../EventSubscriber'
 
     Codein\IbexaSeoToolkit\Routing\ApiLoader:
         tags: ['routing.loader']

--- a/bundle/Resources/config/services.yaml
+++ b/bundle/Resources/config/services.yaml
@@ -6,8 +6,6 @@ services:
     _instanceof:
         Codein\IbexaSeoToolkit\Analysis\ParentAnalyzerInterface:
             tags: [ 'codein_ibexa_seo_toolkit.seo_analyzer.parent_interface' ]
-        Codein\IbexaSeoToolkit\Analysis\AnalyzerInterface:
-            tags: [ 'codein_ibexa_seo_toolkit.seo_analyzer' ]
 
     Codein\IbexaSeoToolkit\Analysis\:
         resource: '../../Analysis/*'

--- a/docs/usage/SITEMAP.md
+++ b/docs/usage/SITEMAP.md
@@ -34,3 +34,11 @@ codein_ibexa_seo_toolkit:
 ## Result
 
 <img src="../img/SitemapExample.png">
+
+## Extensibility
+
+You can modify the sitemap `LocationQuery` by plugin an event subscriber on the `Codein\IbexaSeoToolkit\Event\SitemapQueryEvent`
+
+The default `SitemapQueryEventSubscriber` will merge the base criteria, the blocklist criteria and the passlist criteria
+in a `eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd`
+


### PR DESCRIPTION
The `Codein\IbexaSeoToolkit\Analysis\AnalyzerInterface` needs to be registered for autoconfiguration to get the external analyzers tagged

Extensibility point for the SitemapQuery via `SitemapQueryEvent`

* The event gives access to each part of the query so we can manipulate them from our App (ex: add a field value criterion, etc.)